### PR TITLE
Add support for custom bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Annotate dependencies:
 
 ```javascript
 import {
+    bind,
     Factory,
     Inject,
     Injector,
@@ -38,6 +39,36 @@ Get instance with injected dependencies:
 var injector = new Injector();
 var barService: BarService = injector.get(BarService);
 barService.fooService.constructor === FooService; // true
+```
+
+Bind an arbitrary object to a class or interface:
+
+```javascript
+var fooInstance = {
+    getValue() {
+        return 42;
+    }
+};
+
+class Foo {
+    getValue() {
+        return;
+    }
+}
+
+@Inject(Foo)
+class Bar {
+    constructor(foo: Foo) {
+        this.foo = foo;
+    }
+}
+
+var injector = new Injector([
+    bind(fooInstance).to(Foo)
+]);
+
+var bar: Bar = injector.get(Bar);
+bar.foo.getValue(); // 42
 ```
 
 Provide alternative dependencies (for mocking, etc):

--- a/bin/test
+++ b/bin/test
@@ -5,6 +5,7 @@ var path = require("path");
 
 require("babel/register")({
     optional: [
+        "es7.classProperties",
         "es7.decorators"
     ]
 });

--- a/src/binding.js
+++ b/src/binding.js
@@ -1,0 +1,53 @@
+export class Binding {
+    getProvider(): any {
+        return this.provider;
+    }
+
+    setProvider(provider: any): void {
+        this.provider = provider;
+    }
+
+    getTarget(): Function {
+        return this.target;
+    }
+
+    setTarget(token: Function): void {
+        this.target = token;
+    }
+
+    to(token: Function): Binding {
+        this.setTarget(token);
+        return this;
+    }
+}
+
+/**
+ * Bind an object or instance to a module.
+ *
+ * Usage:
+ *
+ *     class Foo {
+ *
+ *     }
+ *
+ *     @Inject(Foo)
+ *     class Bar {
+ *         constructor(foo: Foo) {
+ *             this.foo = foo;
+ *         }
+ *     }
+ *
+ *     var fooInstance = { name: "foo", getValue() { ... } };
+ *
+ *     var injector = new Injector([
+ *         bind(fooInstance).to(Foo)
+ *     ]);
+ *
+ *     var bar = injector.get(Bar);
+ *     bar.foo === fooInstance; // true
+ */
+export function bind(provider: any): Binding {
+    var binding = new Binding();
+    binding.setProvider(provider);
+    return binding;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
 import { Inject, Provides } from "./annotations";
+import { bind } from "./binding";
 import { Factory } from "./factory";
 import { Injector } from "./injector";
 
 export {
+    bind,
     Factory,
     Inject,
     Injector,

--- a/src/injector.js
+++ b/src/injector.js
@@ -1,5 +1,7 @@
 /** @flow */
 
+import { Binding } from "./binding";
+
 /**
  * DI Service container.
  *
@@ -44,16 +46,19 @@ export class Injector {
         );
     }
 
-    registerProvider(provider: Function): void {
-        var token = provider.__provides || provider;
-        this.providers.set(token, provider);
+    registerProvider(provider: Binding | Function): void {
+        var token;
+
+        if (provider instanceof Binding) {
+            token = provider.getTarget();
+            this.cache.set(token, provider.getProvider());
+        } else {
+            token = provider.__provides || provider;
+            this.providers.set(token, provider);
+        }
     }
 
     get(token: Function): any {
-        return this.getOrCreate(token);
-    }
-
-    getOrCreate(token: Function): any {
         if (this.cache.has(token)) {
             return this.cache.get(token);
         }
@@ -69,7 +74,7 @@ export class Injector {
         var dependencyTokens = provider.__inject || [];
 
         var dependencies = dependencyTokens.map(
-            (token) => this.getOrCreate(token)
+            (token) => this.get(token)
         );
 
         var instance = new provider(...dependencies);

--- a/test/injector.js
+++ b/test/injector.js
@@ -1,5 +1,5 @@
 import test from "tape";
-import { Factory, Inject, Injector, Provides } from "../src";
+import { bind, Factory, Inject, Injector, Provides } from "../src";
 
 test("Basic injection", function(t) {
     t.plan(1);
@@ -125,7 +125,7 @@ test("Factory provider", function(t) {
 
     var useFoo = true;
     var injector1 = new Injector();
-    var baz = injector1.get(Baz);
+    injector1.get(Baz);
 
     @Inject(fooFactory)
     class Quux {
@@ -136,6 +136,35 @@ test("Factory provider", function(t) {
 
     useFoo = false;
     var injector2 = new Injector();
-    var quux = injector2.get(Quux);
+    injector2.get(Quux);
+});
 
+test("Custom binding", function(t) {
+    t.plan(2);
+
+    class Foo {
+        name = "Foo";
+    }
+
+    class Bar {
+        name = "Bar";
+    }
+
+    var a = { name: "a" };
+    var b = { name: "b" };
+
+    var injector = new Injector([
+        bind(a).to(Foo),
+        bind(b).to(Bar)
+    ]);
+
+    @Inject(Foo, Bar)
+    class Baz {
+        constructor(foo: Foo, bar: Bar) {
+            t.equal(foo, a);
+            t.equal(bar, b);
+        }
+    }
+
+    injector.get(Baz);
 });


### PR DESCRIPTION
This adds support for arbitrarily binding objects to another class or interface.

Usage:

```javascript
var fooInstance = {
  getValue() {
    return 42;
  }
};

class Foo {
  getValue() {
    return;
  }
}

var injector = new Injector([
  bind(fooInstance).to(Foo)
]);
```

This probably offers a saner route for mocking dependencies. I think we'll need to clarify the difference between `bind` and `@Provides`, as they both offer a way to replace dependencies. I guess the main difference is that `@Provides` allows you to define a _variant_ of a class or interface (i.e. a specific implementation with its own dependency graph, such as a database driver), whereas `bind` is more appropriate for mocking. I don't have a particular strong opinion about which of these patterns is better, though their behaviours and use cases are probably slightly different.