### PR TITLE
Change the binding logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 npm-debug.log
 .DS_Store
 ._*
+.idea/

--- a/README.md
+++ b/README.md
@@ -41,18 +41,18 @@ var barService: BarService = injector.get(BarService);
 barService.fooService.constructor === FooService; // true
 ```
 
-Bind an arbitrary object to a class or interface:
+Bind an object of a class to an instance of another class:
 
 ```javascript
-var fooInstance = {
-    getValue() {
-        return 42;
-    }
-};
-
 class Foo {
     getValue() {
         return;
+    }
+}
+
+class OtherFoo {
+    getValue() {
+        return 42;
     }
 }
 
@@ -64,7 +64,30 @@ class Bar {
 }
 
 var injector = new Injector([
-    bind(fooInstance).to(Foo)
+    bind(Foo).to(OtherFoo) //
+]);
+
+var bar: Bar = injector.get(Bar);
+bar.foo.getValue(); // 42
+```
+Bind a string token to an instance of a class:
+
+```javascript
+class Foo {
+    getValue() {
+        return 42;
+    }
+}
+
+@Inject("foo")
+class Bar {
+    constructor(foo: Foo) {
+        this.foo = foo;
+    }
+}
+
+var injector = new Injector([
+    bind("foo").to(Foo)
 ]);
 
 var bar: Bar = injector.get(Bar);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jecht",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Dependency injection for modern JS",
   "main": "dist/index.js",
   "scripts": {

--- a/src/binding.js
+++ b/src/binding.js
@@ -1,8 +1,8 @@
 const CLASS_PROVIDER = Symbol();
 
 type Provider = {
-    type: Symbol,
-    value: any
+    type: Symbol;
+    value: any;
 }
 
 export class Binding {

--- a/src/binding.js
+++ b/src/binding.js
@@ -1,22 +1,22 @@
 export class Binding {
-    getProvider(): any {
+    getProvider(): Function {
         return this.provider;
     }
 
-    setProvider(provider: any): void {
+    setProvider(provider: Function): void {
         this.provider = provider;
     }
 
-    getTarget(): Function {
-        return this.target;
+    getToken(): Function {
+        return this.token;
     }
 
-    setTarget(token: Function): void {
-        this.target = token;
+    setToken(token: any): void {
+        this.token = token;
     }
 
-    to(token: Function): Binding {
-        this.setTarget(token);
+    to(provider: Function): Binding {
+        this.setProvider(provider);
         return this;
     }
 }
@@ -40,14 +40,14 @@ export class Binding {
  *     var fooInstance = { name: "foo", getValue() { ... } };
  *
  *     var injector = new Injector([
- *         bind(fooInstance).to(Foo)
+ *         bind(Foo).to(fooInstance)
  *     ]);
  *
  *     var bar = injector.get(Bar);
  *     bar.foo === fooInstance; // true
  */
-export function bind(provider: any): Binding {
+export function bind(token: any): Binding {
     var binding = new Binding();
-    binding.setProvider(provider);
+    binding.setToken(token);
     return binding;
 }

--- a/src/binding.js
+++ b/src/binding.js
@@ -1,9 +1,21 @@
+const CLASS_PROVIDER = Symbol();
+
+type Provider = {
+    type: Symbol,
+    value: any
+}
+
 export class Binding {
-    getProvider(): Function {
-        return this.provider;
+    getProvider(): any {
+        switch (this.provider.type) {
+            case CLASS_PROVIDER:
+                return new this.provider.value();
+            default:
+                return this.provider.value;
+        }
     }
 
-    setProvider(provider: Function): void {
+    setProvider(provider: Provider): void {
         this.provider = provider;
     }
 
@@ -16,7 +28,15 @@ export class Binding {
     }
 
     to(provider: Function): Binding {
-        this.setProvider(provider);
+        return this.toClass(provider);
+    }
+
+    toClass(provider: Function): Binding {
+        this.setProvider({
+            type: CLASS_PROVIDER,
+            value: provider
+        });
+
         return this;
     }
 }

--- a/src/injector.js
+++ b/src/injector.js
@@ -47,14 +47,10 @@ export class Injector {
     }
 
     registerProvider(provider: Binding | Function): void {
-        var token;
-
         if (provider instanceof Binding) {
-            token = provider.getTarget();
-            this.cache.set(token, provider.getProvider());
+            this.cache.set(provider.getToken(), provider.getProvider());
         } else {
-            token = provider.__provides || provider;
-            this.providers.set(token, provider);
+            this.providers.set(provider.__provides || provider, provider);
         }
     }
 

--- a/test/injector.js
+++ b/test/injector.js
@@ -166,3 +166,25 @@ test("Custom binding", function(t) {
 
     injector.get(Baz);
 });
+
+test("String binding tokens", function(t) {
+    t.plan(1);
+
+    class Foo {
+        name = "Foo";
+    }
+
+    var injector = new Injector([
+        bind("String_Token").to(Foo)
+    ]);
+
+    @Inject("String_Token")
+    class Baz {
+        constructor(foo: Foo) {
+            t.comment(foo.constructor);
+            t.true(foo instanceof Foo);
+        }
+    }
+
+    injector.get(Baz);
+});

--- a/test/injector.js
+++ b/test/injector.js
@@ -150,19 +150,17 @@ test("Custom binding", function(t) {
         name = "Bar";
     }
 
-    var a = { name: "a" };
-    var b = { name: "b" };
-
     var injector = new Injector([
-        bind(Foo).to(a),
-        bind(Bar).to(b)
+        bind(Foo).to(Foo),
+        bind(Bar).to(Bar)
     ]);
 
     @Inject(Foo, Bar)
     class Baz {
         constructor(foo: Foo, bar: Bar) {
-            t.equal(foo, a);
-            t.equal(bar, b);
+            t.comment(foo.constructor);
+            t.true(foo instanceof Foo);
+            t.true(bar instanceof Bar);
         }
     }
 

--- a/test/injector.js
+++ b/test/injector.js
@@ -154,8 +154,8 @@ test("Custom binding", function(t) {
     var b = { name: "b" };
 
     var injector = new Injector([
-        bind(a).to(Foo),
-        bind(b).to(Bar)
+        bind(Foo).to(a),
+        bind(Bar).to(b)
     ]);
 
     @Inject(Foo, Bar)

--- a/test/injector.js
+++ b/test/injector.js
@@ -143,24 +143,29 @@ test("Custom binding", function(t) {
     t.plan(2);
 
     class Foo {
+    }
+
+    class OtherFoo {
         name = "Foo";
     }
 
     class Bar {
+    }
+
+    class OtherBar {
         name = "Bar";
     }
 
     var injector = new Injector([
-        bind(Foo).to(Foo),
-        bind(Bar).to(Bar)
+        bind(Foo).to(OtherFoo),
+        bind(Bar).to(OtherBar)
     ]);
 
     @Inject(Foo, Bar)
     class Baz {
         constructor(foo: Foo, bar: Bar) {
-            t.comment(foo.constructor);
-            t.true(foo instanceof Foo);
-            t.true(bar instanceof Bar);
+            t.true(foo instanceof OtherFoo);
+            t.true(bar instanceof OtherBar);
         }
     }
 
@@ -181,7 +186,6 @@ test("String binding tokens", function(t) {
     @Inject("String_Token")
     class Baz {
         constructor(foo: Foo) {
-            t.comment(foo.constructor);
             t.true(foo instanceof Foo);
         }
     }


### PR DESCRIPTION
Bindining are operating in the reverse order. First we need to specify the token and then the provider for that token.

For example `bind(IFoo).to(Foo)`, when we now ask for object of type IFoo we get an instance of class Foo.

This is similar to the way some other IoC work e.g. Ninject, Angular 2 DI